### PR TITLE
【修正案】リンク切れと誤字

### DIFF
--- a/_pages/education.md
+++ b/_pages/education.md
@@ -10,10 +10,10 @@ POCLABでは、学部・大学院教育を通じて次世代の研究者育成�
 
 ## 化学者はコンピュータで必ずモデリング(計算や機械学習)をしてから実験をすることになると予測されている
 
-> **15 years no chemist will do bench experiments without computer-modelling them first**
+> **In 15 years no chemist will do bench experiments without computer-modelling them first**
 > (15年後、化学者はまずコンピューターでモデリングすることなしにベンチ実験を行うことはないだろう。)
 > 参考資料: 
-> [Next RSC president predicts that in 15 years no chemist will do bench experiments without computer-modelling them first](https://www.rsc.org/news-events/articles/2013/07-july/next-rsc-president-predicts-that-in-15-years-no-chemist-will-do-bench-experiments-without-computer-modelling-them-first/)
+> [Next RSC president predicts that in 15 years no chemist will do bench experiments without computer-modelling them first](https://phys.org/news/2013-07-rsc-years-chemist-bench-computer-modelling.html#goog_rewarded)
 
 今後も需要は大きくなると予想されていますが、行える人が圧倒的に少ないのが現状です。
 


### PR DESCRIPTION
### [Education](https://poclab-web.github.io/homepage/education/)の以下の記述について

## 化学者はコンピュータで必ずモデリング(計算や機械学習)をしてから実験をすることになると予測されている

> **15 years no chemist will do bench experiments without computer-modelling them first**
> (15年後、化学者はまずコンピューターでモデリングすることなしにベンチ実験を行うことはないだろう。)
> 参考資料: 
> [Next RSC president predicts that in 15 years no chemist will do bench experiments without computer-modelling them first](https://www.rsc.org/news-events/articles/2013/07-july/next-rsc-president-predicts-that-in-15-years-no-chemist-will-do-bench-experiments-without-computer-modelling-them-first/)

---

- 「15年後」なので、"15 years"ではなく、参考資料のタイトル通り"in 15 years"とした方が良いと思います。
- 参考資料のリンクにアクセスできなくなっていたので、代替リンクに差し替えました。元のリンク先と同じ記事かどうか、確認をお願いします。 https://phys.org/news/2013-07-rsc-years-chemist-bench-computer-modelling.html#goog_rewarded
